### PR TITLE
fix: use correct Gamma API parameter for filtering open markets

### DIFF
--- a/src/polymarket_mcp/tools/market_discovery.py
+++ b/src/polymarket_mcp/tools/market_discovery.py
@@ -133,8 +133,8 @@ async def get_trending_markets(
         Top markets by volume in the specified timeframe
     """
     try:
-        # Fetch all active markets
-        markets = await _fetch_gamma_markets("/markets", {"active": "true"}, limit=100)
+        # Fetch all open markets
+        markets = await _fetch_gamma_markets("/markets", {"closed": "false"}, limit=100)
 
         # Sort by volume based on timeframe
         volume_key_map = {
@@ -182,7 +182,7 @@ async def filter_markets_by_category(
         params = {"tag": category}
 
         if active_only:
-            params["active"] = "true"
+            params["closed"] = "false"
 
         markets = await _fetch_gamma_markets("/markets", params, limit)
 
@@ -246,7 +246,7 @@ async def get_featured_markets(limit: int = 10) -> List[Dict[str, Any]]:
     """
     try:
         # Fetch markets with featured flag
-        params = {"featured": "true", "active": "true"}
+        params = {"featured": "true", "closed": "false"}
         markets = await _fetch_gamma_markets("/markets", params, limit)
 
         # If no featured flag exists, return highest volume markets
@@ -281,8 +281,8 @@ async def get_closing_soon_markets(
         cutoff_time = datetime.utcnow() + timedelta(hours=hours)
         cutoff_timestamp = int(cutoff_time.timestamp())
 
-        # Fetch active markets
-        markets = await _fetch_gamma_markets("/markets", {"active": "true"}, limit=100)
+        # Fetch open markets
+        markets = await _fetch_gamma_markets("/markets", {"closed": "false"}, limit=100)
 
         # Filter markets closing within timeframe
         closing_soon = []
@@ -332,7 +332,7 @@ async def get_sports_markets(
         Sports markets
     """
     try:
-        params = {"tag": "Sports", "active": "true"}
+        params = {"tag": "Sports", "closed": "false"}
 
         markets = await _fetch_gamma_markets("/markets", params, limit=100)
 
@@ -371,7 +371,7 @@ async def get_crypto_markets(
         Crypto-related markets
     """
     try:
-        params = {"tag": "Crypto", "active": "true"}
+        params = {"tag": "Crypto", "closed": "false"}
 
         markets = await _fetch_gamma_markets("/markets", params, limit=100)
 


### PR DESCRIPTION
## 📋 Description

The Gamma API requires `closed: "false"` to filter for open/active markets, not `active: "true"` which was being used. This caused all market discovery tools (trending, categories, featured, etc.) to return only closed markets from 2020 instead of current active markets.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvements
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement

## 🔗 Related Issues

Markets discovery tools return closed markets from 2020 instead of current open markets when using demo mode (or any mode).

## 🧪 Testing

### Test Configuration

- **Python Version**: 3.14
- **OS**: macOS
- **Branch**: fix/gamma-api-market-filter-parameter

### Tests Performed

- [x] All existing tests pass (`pytest`)
- [ ] Added new tests for new functionality
- [x] Tested manually with real Polymarket API
- [x] Verified safety limits still work
- [x] Tested with Claude Desktop integration

### Test Results

```
tests/test_market_tools.py::TestMarketDiscovery::test_search_markets PASSED
tests/test_market_tools.py::TestMarketDiscovery::test_get_trending_markets PASSED
tests/test_market_tools.py::TestMarketDiscovery::test_filter_markets_by_category PASSED
tests/test_market_tools.py::TestMarketDiscovery::test_get_featured_markets PASSED
tests/test_market_tools.py::TestMarketDiscovery::test_get_closing_soon_markets PASSED
tests/test_market_tools.py::TestMarketDiscovery::test_get_sports_markets PASSED
tests/test_market_tools.py::TestMarketDiscovery::test_get_crypto_markets PASSED
tests/test_market_tools.py::TestMarketDiscovery::test_get_event_markets PASSED
======================== 8 passed, 1 warning in 12.01s =========================
```

## 📸 Screenshots / Examples

Before fix - returns 2020 closed markets:
```
Markets from 2020...
```

After fix - returns current open markets:
```python
# Trending markets now correctly return current 2025 markets:
- "Russia x Ukraine ceasefire in 2025?" (ends: 2025-12-31)
- "Will Bitcoin reach $1,000,000 by December 31, 2025?" (ends: 2025-12-31)
- "Will Bitcoin reach $200,000 by December 31, 2025?" (ends: 2025-12-31)
```

## ✅ Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have checked my code and corrected any misspellings
- [ ] I have updated the CHANGELOG.md file

## 🔒 Security

- [x] This PR does not introduce security vulnerabilities
- [x] I have verified no credentials are exposed
- [x] Safety limits are still enforced
- [x] Input validation is adequate

## ⚠️ Breaking Changes

**Does this PR introduce breaking changes?**

- [ ] Yes (describe below)
- [x] No

## 💬 Additional Notes

Changed all 6 affected functions in `src/polymarket_mcp/tools/market_discovery.py`:
- `get_trending_markets()` - line 137
- `filter_markets_by_category()` - line 185
- `get_featured_markets()` - line 249
- `get_closing_soon_markets()` - line 285
- `get_sports_markets()` - line 335
- `get_crypto_markets()` - line 374

The fix simply changes the API parameter from `{"active": "true"}` to `{"closed": "false"}` which is what the Gamma API actually expects. This can be verified in `test_real_data.py` which already uses the correct parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)