### PR TITLE
Update repository URLs from caiovicentino to joe67-67

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,7 +290,7 @@ We are committed to providing a welcoming and inspiring community for all.
 
 Need help contributing?
 
-- 💬 **[GitHub Discussions](https://github.com/caiovicentino/polymarket-mcp-server/discussions)** - Ask questions
+- 💬 **[GitHub Discussions](https://github.com/joe67-67/polymarket-mcp-server/discussions)** - Ask questions
 - 📱 **[Telegram Communities](#)** - Chat with community members
 - 📧 **Email**: Contact project maintainers
 
@@ -352,8 +352,8 @@ Together, we're building the future of AI-powered prediction market trading! �
 ## 📞 Contact
 
 - **Project Maintainer**: [Caio Vicentino](https://github.com/caiovicentino)
-- **Issues**: [GitHub Issues](https://github.com/caiovicentino/polymarket-mcp-server/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/caiovicentino/polymarket-mcp-server/discussions)
+- **Issues**: [GitHub Issues](https://github.com/joe67-67/polymarket-mcp-server/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/joe67-67/polymarket-mcp-server/discussions)
 
 ---
 

--- a/DEMO_VIDEO_SCRIPT.md
+++ b/DEMO_VIDEO_SCRIPT.md
@@ -33,7 +33,7 @@ Complete script for creating demonstration videos.
 
 **[Show: Terminal commands]**
 ```bash
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 python -m venv venv
 source venv/bin/activate
@@ -250,7 +250,7 @@ Subscribe to price changes for [market_id]
 **[Show: Links and resources]**
 
 **Resources:**
-- GitHub: github.com/caiovicentino/polymarket-mcp-server
+- GitHub: github.com/joe67-67/polymarket-mcp-server
 - Documentation: Full guides in repository
 - Community: Yield Hacker, Renda Cripto, Cultura Builder
 
@@ -279,7 +279,7 @@ Subscribe to price changes for [market_id]
 
 **Method 1: GUI Wizard (60 seconds):**
 ```bash
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 python -m venv venv
 source venv/bin/activate
@@ -291,7 +291,7 @@ python setup_wizard.py
 
 **Method 2: Automated Script (45 seconds):**
 ```bash
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 chmod +x install.sh
 ./install.sh
@@ -301,7 +301,7 @@ chmod +x install.sh
 
 **Method 3: Docker (30 seconds):**
 ```bash
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 cp .env.example .env
 # Edit .env
@@ -560,7 +560,7 @@ Buy $400 of YES tokens in [market]
 
 **Links in Description:**
 ```
-🔗 GitHub Repository: https://github.com/caiovicentino/polymarket-mcp-server
+🔗 GitHub Repository: https://github.com/joe67-67/polymarket-mcp-server
 📖 Documentation: [link to README]
 💬 Discord: [invite link]
 🐦 Twitter: @caiovicentino

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -37,7 +37,7 @@ Complete installation guide for the Polymarket MCP Server with automated scripts
 
 ```bash
 # One command - installs DEMO mode automatically
-curl -sSL https://raw.githubusercontent.com/caiovicentino/polymarket-mcp-server/main/quickstart.sh | bash
+curl -sSL https://raw.githubusercontent.com/joe67-67/polymarket-mcp-server/main/quickstart.sh | bash
 ```
 
 This will:
@@ -61,7 +61,7 @@ This will:
 
 ```bash
 # Clone repository
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 
 # Run installer
@@ -77,7 +77,7 @@ cd polymarket-mcp-server
 
 ```batch
 REM Clone repository
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 
 REM Run installer
@@ -95,7 +95,7 @@ install.bat
 
 ```bash
 # 1. Clone repository
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 
 # 2. Create virtual environment
@@ -434,7 +434,7 @@ python -c "from polymarket_mcp.config import load_config; print(load_config().DE
 - [TEST_INSTALLATION.md](TEST_INSTALLATION.md) - Testing guide
 
 **Report Issues:**
-- GitHub Issues: https://github.com/caiovicentino/polymarket-mcp-server/issues
+- GitHub Issues: https://github.com/joe67-67/polymarket-mcp-server/issues
 - Include error messages and system info
 
 **Community Support:**

--- a/INSTALLATION_SUMMARY.md
+++ b/INSTALLATION_SUMMARY.md
@@ -610,7 +610,7 @@ Successfully transformed Polymarket MCP Server installation from a complex 10+ s
 
 ## Support
 
-**Issues:** https://github.com/caiovicentino/polymarket-mcp-server/issues
+**Issues:** https://github.com/joe67-67/polymarket-mcp-server/issues
 
 **Documentation:**
 - [INSTALLATION.md](INSTALLATION.md)

--- a/PROJECT_COMPLETE.md
+++ b/PROJECT_COMPLETE.md
@@ -2,7 +2,7 @@
 
 ## ✅ Status: PRODUCTION READY & TOTALMENTE ACESSÍVEL
 
-**Repositório:** https://github.com/caiovicentino/polymarket-mcp-server
+**Repositório:** https://github.com/joe67-67/polymarket-mcp-server
 **Versão:** v0.1.0 (com melhorias massivas)
 **Data:** 11 de Novembro de 2025
 
@@ -45,7 +45,7 @@
 ### 1️⃣ Quick Start (MAIS RÁPIDO - 30 segundos)
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/caiovicentino/polymarket-mcp-server/main/quickstart.sh | bash
+curl -sSL https://raw.githubusercontent.com/joe67-67/polymarket-mcp-server/main/quickstart.sh | bash
 ```
 
 ✅ **Sem wallet** - Modo DEMO
@@ -55,7 +55,7 @@ curl -sSL https://raw.githubusercontent.com/caiovicentino/polymarket-mcp-server/
 ### 2️⃣ Install Script (RECOMENDADO - 1 minuto)
 
 ```bash
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 ./install.sh
 ```
@@ -306,13 +306,13 @@ polymarket-web
 
 ### **Opção 1: Mais Rápido (30s)**
 ```bash
-curl -sSL https://raw.githubusercontent.com/caiovicentino/polymarket-mcp-server/main/quickstart.sh | bash
+curl -sSL https://raw.githubusercontent.com/joe67-67/polymarket-mcp-server/main/quickstart.sh | bash
 ```
 **Resultado:** DEMO mode instalado, 25 tools disponíveis
 
 ### **Opção 2: Mais Fácil (2min)**
 ```bash
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 python setup_wizard.py
 ```
@@ -320,7 +320,7 @@ python setup_wizard.py
 
 ### **Opção 3: Docker (1min)**
 ```bash
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 cp .env.example .env
 # Editar .env se quiser trading
@@ -364,11 +364,11 @@ docker compose up -d
 
 | Recurso | URL |
 |---------|-----|
-| 📦 **GitHub** | https://github.com/caiovicentino/polymarket-mcp-server |
+| 📦 **GitHub** | https://github.com/joe67-67/polymarket-mcp-server |
 | 📖 **Docs** | Ver arquivos .md no repo |
 | 🎥 **Videos** | Ver DEMO_VIDEO_SCRIPT.md |
-| 💬 **Issues** | https://github.com/caiovicentino/polymarket-mcp-server/issues |
-| 🗣️ **Discussions** | https://github.com/caiovicentino/polymarket-mcp-server/discussions |
+| 💬 **Issues** | https://github.com/joe67-67/polymarket-mcp-server/issues |
+| 🗣️ **Discussions** | https://github.com/joe67-67/polymarket-mcp-server/discussions |
 
 ### **Comunidades**
 - 🌾 **[Yield Hacker](https://opensea.io/collection/yield-hacker-pass-yhp)**
@@ -538,4 +538,4 @@ docker compose up -d
 *Com Yield Hacker, Renda Cripto e Cultura Builder*
 *Powered by Claude Code (Anthropic)*
 
-**⭐ Star o repo:** https://github.com/caiovicentino/polymarket-mcp-server
+**⭐ Star o repo:** https://github.com/joe67-67/polymarket-mcp-server

--- a/QUICKSTART_GUIDE.md
+++ b/QUICKSTART_GUIDE.md
@@ -10,7 +10,7 @@ Get started in 5 minutes with the easiest installation path.
 
 ```bash
 # Clone the repository
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 
 # Create virtual environment

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -6,7 +6,7 @@ One-page reference for Polymarket MCP Server installation and usage.
 
 ```bash
 # Fastest: One-command DEMO mode
-curl -sSL https://raw.githubusercontent.com/caiovicentino/polymarket-mcp-server/main/quickstart.sh | bash
+curl -sSL https://raw.githubusercontent.com/joe67-67/polymarket-mcp-server/main/quickstart.sh | bash
 
 # DEMO mode (local)
 ./install.sh --demo
@@ -139,7 +139,7 @@ REQUIRE_CONFIRMATION_ABOVE_USD=500  # Confirm first
 
 ## Support
 
-- Issues: https://github.com/caiovicentino/polymarket-mcp-server/issues
+- Issues: https://github.com/joe67-67/polymarket-mcp-server/issues
 - Docs: [INSTALLATION.md](INSTALLATION.md)
 - Tests: [TEST_INSTALLATION.md](TEST_INSTALLATION.md)
 

--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ See [WEB_DASHBOARD.md](WEB_DASHBOARD.md) for complete documentation.
 **Try DEMO mode first** (no wallet needed):
 ```bash
 # macOS/Linux
-curl -sSL https://raw.githubusercontent.com/caiovicentino/polymarket-mcp-server/main/quickstart.sh | bash
+curl -sSL https://raw.githubusercontent.com/joe67-67/polymarket-mcp-server/main/quickstart.sh | bash
 
 # Or clone and run locally
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 ./quickstart.sh
 ```
@@ -202,7 +202,7 @@ If you prefer manual setup:
 
 ```bash
 # Clone the repository
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 
 # Create virtual environment
@@ -475,8 +475,8 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on:
 
 ### Get Support
 
-- **GitHub Issues**: [Report bugs or request features](https://github.com/caiovicentino/polymarket-mcp-server/issues)
-- **GitHub Discussions**: [Ask questions and share ideas](https://github.com/caiovicentino/polymarket-mcp-server/discussions)
+- **GitHub Issues**: [Report bugs or request features](https://github.com/joe67-67/polymarket-mcp-server/issues)
+- **GitHub Discussions**: [Ask questions and share ideas](https://github.com/joe67-67/polymarket-mcp-server/discussions)
 - **Telegram Communities**: Get help from the community
 
 ---
@@ -523,7 +523,7 @@ The authors and contributors are not responsible for any financial losses incurr
 
 ## 🔗 Links
 
-- **GitHub Repository**: [github.com/caiovicentino/polymarket-mcp-server](https://github.com/caiovicentino/polymarket-mcp-server)
+- **GitHub Repository**: [github.com/joe67-67/polymarket-mcp-server](https://github.com/joe67-67/polymarket-mcp-server)
 - **Polymarket**: [polymarket.com](https://polymarket.com)
 - **Polymarket Docs**: [docs.polymarket.com](https://docs.polymarket.com)
 - **MCP Protocol**: [modelcontextprotocol.io](https://modelcontextprotocol.io)
@@ -558,6 +558,6 @@ The authors and contributors are not responsible for any financial losses incurr
 
 *Ready to make Claude your personal prediction market trader!* 🚀
 
-[⭐ Star this repo](https://github.com/caiovicentino/polymarket-mcp-server) | [🐛 Report Bug](https://github.com/caiovicentino/polymarket-mcp-server/issues) | [✨ Request Feature](https://github.com/caiovicentino/polymarket-mcp-server/issues)
+[⭐ Star this repo](https://github.com/joe67-67/polymarket-mcp-server) | [🐛 Report Bug](https://github.com/joe67-67/polymarket-mcp-server/issues) | [✨ Request Feature](https://github.com/joe67-67/polymarket-mcp-server/issues)
 
 </div>

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -254,7 +254,7 @@ polymarket-mcp/
 
 **Easiest - GUI Wizard:**
 ```bash
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 python -m venv venv
 source venv/bin/activate

--- a/TEST_INSTALLATION.md
+++ b/TEST_INSTALLATION.md
@@ -25,7 +25,7 @@ Complete guide for testing the Polymarket MCP Server installation scripts.
 **Steps:**
 ```bash
 # 1. Clone repository (or use existing)
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 
 # 2. Run installer
@@ -115,7 +115,7 @@ cat .env | grep MAX_ORDER_SIZE_USD
 **Steps (on Windows):**
 ```batch
 REM Download repository
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 
 REM Run installer in DEMO mode
@@ -161,7 +161,7 @@ python -c "import polymarket_mcp"
 **Steps:**
 ```bash
 # Method 1: Download and run
-curl -sSL https://raw.githubusercontent.com/caiovicentino/polymarket-mcp-server/main/quickstart.sh | bash
+curl -sSL https://raw.githubusercontent.com/joe67-67/polymarket-mcp-server/main/quickstart.sh | bash
 
 # Method 2: Local run
 ./quickstart.sh
@@ -397,12 +397,12 @@ python3.9 -m venv test_venv
 # Install in multiple directories
 mkdir ~/poly-test-1
 cd ~/poly-test-1
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git .
+git clone https://github.com/joe67-67/polymarket-mcp-server.git .
 ./install.sh --demo
 
 mkdir ~/poly-test-2
 cd ~/poly-test-2
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git .
+git clone https://github.com/joe67-67/polymarket-mcp-server.git .
 ./install.sh --demo
 ```
 
@@ -542,7 +542,7 @@ If tests fail:
 2. Check permissions: `ls -la install.sh`
 3. Check internet connection: `curl -I https://pypi.org`
 4. Check logs: Review terminal output
-5. Report issue: https://github.com/caiovicentino/polymarket-mcp-server/issues
+5. Report issue: https://github.com/joe67-67/polymarket-mcp-server/issues
 
 ---
 

--- a/VISUAL_INSTALL_GUIDE.md
+++ b/VISUAL_INSTALL_GUIDE.md
@@ -83,7 +83,7 @@ Complete step-by-step installation guide with diagrams and troubleshooting.
 
 ```bash
 # Clone the repository
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 ```
 
@@ -180,7 +180,7 @@ python setup_wizard.py
 
 ```bash
 # Clone repository
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 
 # Run install script
@@ -199,7 +199,7 @@ The script will:
 
 ```powershell
 # Clone repository
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 
 # Run install script
@@ -214,7 +214,7 @@ cd polymarket-mcp-server
 
 ```bash
 # Clone repository
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 
 # Copy environment template
@@ -256,7 +256,7 @@ docker-compose up -d
 ### Step 1: Clone Repository
 
 ```bash
-git clone https://github.com/caiovicentino/polymarket-mcp-server.git
+git clone https://github.com/joe67-67/polymarket-mcp-server.git
 cd polymarket-mcp-server
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -468,7 +468,7 @@ rollback() {
 
     echo ""
     echo "Please check the error message above and try again."
-    echo "For help, visit: https://github.com/caiovicentino/polymarket-mcp-server/issues"
+    echo "For help, visit: https://github.com/joe67-67/polymarket-mcp-server/issues"
     exit 1
 }
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -6,13 +6,13 @@
 # One-liner to get started with Polymarket MCP Server in DEMO mode
 #
 # Usage:
-#   curl -sSL https://raw.githubusercontent.com/caiovicentino/polymarket-mcp-server/main/quickstart.sh | bash
+#   curl -sSL https://raw.githubusercontent.com/joe67-67/polymarket-mcp-server/main/quickstart.sh | bash
 #
 # Or download and run locally:
 #   ./quickstart.sh
 #
 # Author: Caio Vicentino
-# GitHub: https://github.com/caiovicentino/polymarket-mcp-server
+# GitHub: https://github.com/joe67-67/polymarket-mcp-server
 ################################################################################
 
 set -e
@@ -53,7 +53,7 @@ read
 # Check if we're in the repo directory
 if [ ! -f "pyproject.toml" ]; then
     echo "Cloning repository..."
-    REPO_URL="https://github.com/caiovicentino/polymarket-mcp-server.git"
+    REPO_URL="https://github.com/joe67-67/polymarket-mcp-server.git"
     INSTALL_DIR="$HOME/polymarket-mcp-server"
 
     if [ -d "$INSTALL_DIR" ]; then


### PR DESCRIPTION
# Pull Request

## 📋 Description

This PR updates all repository references throughout the codebase from the original owner `caiovicentino` to the new owner `joe67-67`. This includes updates to:

- GitHub repository URLs in README.md
- Clone URLs in quickstart.sh and install.sh
- Documentation links and references
- Support/issue reporting links
- Repository metadata in script headers

All references now point to `https://github.com/joe67-67/polymarket-mcp-server` instead of `https://github.com/caiovicentino/polymarket-mcp-server`.

## 🎯 Type of Change

- [x] 📖 Documentation update

## 🔗 Related Issues

Fixes #

## 🧪 Testing

No testing needed - this is a documentation and configuration update that only changes repository URLs.

## ✅ Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings

## 📖 Documentation

- [x] README.md updated
- [x] quickstart.sh updated
- [x] install.sh updated

## 🔒 Security

- [x] This PR does not introduce security vulnerabilities
- [x] I have verified no credentials are exposed

## ⚠️ Breaking Changes

**Does this PR introduce breaking changes?**

- [x] No

---

**Thank you for contributing to Polymarket MCP Server!** 🙏

By submitting this PR, you agree that your contributions will be licensed under the MIT License.

https://claude.ai/code/session_01BSCxurWTsFy64YhpvX4kh7