### PR TITLE
fix(web): migrate TemplateResponse to new signature (closes #24)

### DIFF
--- a/src/polymarket_mcp/web/app.py
+++ b/src/polymarket_mcp/web/app.py
@@ -11,6 +11,7 @@ Provides web UI for:
 import asyncio
 import json
 import logging
+from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any, Optional
@@ -32,11 +33,28 @@ from ..tools import market_discovery, market_analysis
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application lifespan: load config on startup, close websockets on shutdown."""
+    await load_mcp_config()
+    logger.info("Polymarket MCP Dashboard started")
+    try:
+        yield
+    finally:
+        for ws in active_websockets:
+            try:
+                await ws.close()
+            except Exception:
+                pass
+        logger.info("Dashboard shutdown complete")
+
+
 # Initialize FastAPI app
 app = FastAPI(
     title="Polymarket MCP Dashboard",
     description="Web dashboard for Polymarket MCP Server",
-    version="0.1.0"
+    version="0.1.0",
+    lifespan=lifespan,
 )
 
 # Template and static file directories
@@ -104,22 +122,6 @@ async def load_mcp_config():
         logger.warning("Dashboard running without MCP connection")
 
 
-@app.on_event("startup")
-async def startup_event():
-    """Initialize dashboard on startup"""
-    await load_mcp_config()
-    logger.info("Polymarket MCP Dashboard started")
-
-
-@app.on_event("shutdown")
-async def shutdown_event():
-    """Cleanup on shutdown"""
-    # Close all websockets
-    for ws in active_websockets:
-        await ws.close()
-    logger.info("Dashboard shutdown complete")
-
-
 # ============================================================================
 # HTML Pages
 # ============================================================================
@@ -141,12 +143,15 @@ async def dashboard_home(request: Request):
         "tools_available": 45 if (client and client.has_api_credentials()) else 25,
     }
 
-    return templates.TemplateResponse("index.html", {
-        "request": request,
-        "mcp_status": mcp_status,
-        "stats": stats,
-        "uptime": str(uptime).split('.')[0],  # Remove microseconds
-    })
+    return templates.TemplateResponse(
+        request,
+        "index.html",
+        {
+            "mcp_status": mcp_status,
+            "stats": stats,
+            "uptime": str(uptime).split('.')[0],  # Remove microseconds
+        },
+    )
 
 
 @app.get("/config", response_class=HTMLResponse)
@@ -176,10 +181,11 @@ async def config_page(request: Request):
             "has_api_credentials": client.has_api_credentials() if client else False,
         }
 
-    return templates.TemplateResponse("config.html", {
-        "request": request,
-        "config": current_config,
-    })
+    return templates.TemplateResponse(
+        request,
+        "config.html",
+        {"config": current_config},
+    )
 
 
 @app.get("/markets", response_class=HTMLResponse)
@@ -187,9 +193,7 @@ async def markets_page(request: Request):
     """Markets discovery and analysis page"""
     stats["requests_total"] += 1
 
-    return templates.TemplateResponse("markets.html", {
-        "request": request,
-    })
+    return templates.TemplateResponse(request, "markets.html")
 
 
 @app.get("/monitoring", response_class=HTMLResponse)
@@ -212,12 +216,15 @@ async def monitoring_page(request: Request):
         "uptime": str(datetime.now() - stats["uptime_start"]).split('.')[0],
     }
 
-    return templates.TemplateResponse("monitoring.html", {
-        "request": request,
-        "stats": stats,
-        "rate_status": rate_status,
-        "system_info": system_info,
-    })
+    return templates.TemplateResponse(
+        request,
+        "monitoring.html",
+        {
+            "stats": stats,
+            "rate_status": rate_status,
+            "system_info": system_info,
+        },
+    )
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Fixes `Internal Server Error` on the web dashboard reported in #24 (Windows 11 + Python 3.14, fresh `install.bat` run)
- Migrates all 4 dashboard routes from the deprecated `TemplateResponse(name, {"request": request, ...})` signature to the current `TemplateResponse(request, name, context)` form
- Replaces deprecated `@app.on_event("startup"|"shutdown")` decorators with a single `lifespan` async context manager

## Why this fixes #24
The `TemplateResponse(name, ctx)` form has been deprecated by Starlette since 0.27 (May 2023) and is now raising in newer Starlette versions installed on fresh Python 3.14 environments. The traceback in #24 lands exactly at the `templates.TemplateResponse(...)` call in `dashboard_home`, which is the deprecated form. The new form is the supported, forward-compatible API.

`@app.on_event` is unrelated to the 500 but is also deprecated; combining both avoids future breakage.

## Test plan
- [x] All 4 routes (`/`, `/config`, `/markets`, `/monitoring`) return 200 with `DeprecationWarning` treated as error (`python -W error::DeprecationWarning`)
- [x] App imports cleanly (AST parse + module import)
- [ ] Manual verification on Windows 11 + Python 3.14 by issue reporter (@french4baguette)

🤖 Generated with [Claude Code](https://claude.com/claude-code)