### PR TITLE
fix: use public search for market queries

### DIFF
--- a/src/polymarket_mcp/tools/market_discovery.py
+++ b/src/polymarket_mcp/tools/market_discovery.py
@@ -85,6 +85,68 @@ async def _fetch_gamma_markets(
         raise
 
 
+def _flatten_public_search_markets(
+    data: Dict[str, Any],
+    limit: Optional[int] = None
+) -> List[Dict[str, Any]]:
+    """Flatten /public-search event results into a market list."""
+    markets = []
+
+    for event in data.get("events") or []:
+        for market in event.get("markets") or []:
+            markets.append(market)
+            if limit and len(markets) >= limit:
+                return markets
+
+    return markets
+
+
+async def _search_gamma_markets(
+    query: str,
+    params: Optional[Dict[str, Any]] = None,
+    limit: Optional[int] = None
+) -> List[Dict[str, Any]]:
+    """
+    Search markets using Gamma's public search endpoint.
+
+    /markets does not apply free-text query parameters, so using it for search
+    returns the default listing regardless of the requested query.
+    """
+    rate_limiter = get_rate_limiter()
+
+    await rate_limiter.acquire(EndpointCategory.GAMMA_API)
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            search_params = {
+                "q": query,
+                "events_status": "active",
+                "keep_closed_markets": 0,
+            }
+
+            if limit:
+                search_params["limit_per_type"] = limit
+
+            if params:
+                search_params.update(params)
+
+            url = f"{GAMMA_API_URL}/public-search"
+            logger.debug(f"Searching markets from {url} with params: {search_params}")
+
+            response = await client.get(url, params=search_params)
+            response.raise_for_status()
+
+            data = response.json()
+            return _flatten_public_search_markets(data, limit)
+
+    except httpx.HTTPError as e:
+        logger.error(f"HTTP error searching markets: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Error searching markets: {e}")
+        raise
+
+
 async def search_markets(
     query: str,
     limit: int = 20,
@@ -103,12 +165,12 @@ async def search_markets(
     """
     try:
         # Fetch markets with search — default to active, non-closed markets
-        params = {"query": query, "active": "true", "closed": "false"}
+        params = {}
 
         if filters:
             params.update(filters)
 
-        markets = await _fetch_gamma_markets("/markets", params, limit)
+        markets = await _search_gamma_markets(query, params, limit)
 
         logger.info(f"Found {len(markets)} markets for query: {query}")
         return markets
@@ -316,7 +378,6 @@ async def get_closing_soon_markets(
     try:
         # Calculate cutoff time
         cutoff_time = datetime.utcnow() + timedelta(hours=hours)
-        cutoff_timestamp = int(cutoff_time.timestamp())
 
         # Fetch active, non-closed markets
         markets = await _fetch_gamma_markets("/markets", {"active": "true", "closed": "false"}, limit=100)

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -6,9 +6,7 @@ Tests for GitHub issue fixes (#2, #6, #10).
 - Issue #2: Market discovery must filter out closed/expired markets
 """
 import pytest
-import logging
-import importlib
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, patch
 from datetime import datetime, timedelta
 
 
@@ -22,7 +20,6 @@ class TestCredentialMasking:
     def test_server_logs_truncated_key(self):
         """Credentials should be logged at DEBUG with only first 8 chars."""
         import polymarket_mcp.server as server_module
-        source = importlib.util.find_spec("polymarket_mcp.server")
         import inspect
         source_code = inspect.getsource(server_module)
 
@@ -121,19 +118,30 @@ class TestMarketFiltering:
     """Verify that market discovery functions filter out old/closed markets."""
 
     @pytest.mark.asyncio
-    async def test_search_markets_sends_active_and_closed_params(self):
-        """search_markets must include active=true and closed=false."""
+    async def test_search_markets_uses_public_search_endpoint(self):
+        """search_markets must use Gamma's public search endpoint."""
         from polymarket_mcp.tools import market_discovery
 
-        with patch.object(market_discovery, "_fetch_gamma_markets", new_callable=AsyncMock) as mock_fetch:
+        with patch.object(market_discovery, "_search_gamma_markets", new_callable=AsyncMock) as mock_fetch:
             mock_fetch.return_value = []
             await market_discovery.search_markets("test", limit=5)
 
-            mock_fetch.assert_called_once()
-            call_args = mock_fetch.call_args
-            params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("params", {})
-            assert params.get("active") == "true", "search_markets must set active=true"
-            assert params.get("closed") == "false", "search_markets must set closed=false"
+            mock_fetch.assert_awaited_once_with("test", {}, 5)
+
+    def test_public_search_flattens_event_markets(self):
+        """public-search event results should be returned as a flat market list."""
+        from polymarket_mcp.tools import market_discovery
+
+        data = {
+            "events": [
+                {"title": "Bitcoin", "markets": [{"question": "BTC above 100k?"}]},
+                {"title": "Ethereum", "markets": [{"question": "ETH above 4k?"}]},
+            ]
+        }
+
+        results = market_discovery._flatten_public_search_markets(data, limit=1)
+
+        assert results == [{"question": "BTC above 100k?"}]
 
     @pytest.mark.asyncio
     async def test_get_trending_markets_sends_active_and_closed_params(self):


### PR DESCRIPTION
## Summary
- route `search_markets` through Gamma `/public-search` instead of `/markets?query=...`
- flatten event search results back into the existing market-list return shape
- add regression coverage for the search endpoint behavior

## Why
`/markets` ignores free-text query parameters, so different queries can return the default listing. This fixes #28 by using Polymarket's documented public search endpoint with `q`.

## Validation
- `python -m ruff check src/polymarket_mcp/tools/market_discovery.py tests/test_issue_fixes.py`
- `python -m pytest tests/test_issue_fixes.py -q`
- live check: `search_markets("Bitcoin", limit=3)` returns Bitcoin markets, not GTA VI markets

Closes #28