### PR TITLE
docs: add Contributors section (auto-updating via contrib.rocks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,14 @@ The authors and contributors are not responsible for any financial losses incurr
 
 ---
 
+## 🌟 Contributors
+
+Thanks to everyone who has contributed to this project!
+
+[![Contributors](https://contrib.rocks/image?repo=caiovicentino/polymarket-mcp-server)](https://github.com/caiovicentino/polymarket-mcp-server/graphs/contributors)
+
+---
+
 <div align="center">
 
 **Built with ❤️ for autonomous AI trading on Polymarket**


### PR DESCRIPTION
Adds an auto-updating contributor avatar grid (contrib.rocks) that pulls from the GitHub contributors API — zero maintenance, recognizes everyone who has contributed.