### PR TITLE
fix: resolve 3 critical trading bugs (#12, #13, #14) + unblock test suite

### DIFF
--- a/src/polymarket_mcp/config.py
+++ b/src/polymarket_mcp/config.py
@@ -50,6 +50,10 @@ class PolymarketConfig(BaseSettings):
         default=None,
         description="API key passphrase"
     )
+    POLYMARKET_API_SECRET: Optional[str] = Field(
+        default=None,
+        description="L2 API secret for WebSocket authentication (falls back to passphrase)"
+    )
     POLYMARKET_API_KEY_NAME: Optional[str] = Field(
         default=None,
         description="API key name/identifier"

--- a/src/polymarket_mcp/server.py
+++ b/src/polymarket_mcp/server.py
@@ -255,7 +255,7 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> list[types.TextCont
                 name,
                 arguments,
                 polymarket_client,
-                safety_limits,
+                get_rate_limiter(),
                 config
             )
 
@@ -400,8 +400,18 @@ async def initialize_server() -> None:
         # Initialize WebSocket manager
         logger.info("Initializing WebSocket manager...")
         websocket_manager = WebSocketManager(config)
-        # Connect WebSocket (non-blocking)
-        asyncio.create_task(websocket_manager.connect())
+
+        # Connect WebSocket AND start the message-processing loop (non-blocking). Previously
+        # only connect() was scheduled, so the background loop that receives messages never
+        # started (issue #13).
+        async def _init_websocket():
+            try:
+                await websocket_manager.connect()
+                await websocket_manager.start_background_task()
+            except Exception as e:
+                logger.warning(f"WebSocket init failed (real-time tools unavailable): {e}")
+
+        asyncio.create_task(_init_websocket())
         logger.info("WebSocket manager initialized with 7 real-time tools")
 
         logger.info("Server initialization complete!")

--- a/src/polymarket_mcp/tools/trading.py
+++ b/src/polymarket_mcp/tools/trading.py
@@ -4,6 +4,7 @@ Implements 12 comprehensive tools for order management and smart trading.
 """
 import asyncio
 import json
+import re
 import logging
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional, Tuple
@@ -46,6 +47,30 @@ class TradingTools:
 
     # ========== ORDER CREATION TOOLS ==========
 
+    @staticmethod
+    def _select_token(tokens: list, outcome: str = "YES") -> str:
+        """Resolve the token_id for the requested market outcome (YES/NO).
+
+        Polymarket binary markets expose two outcome tokens. This code historically used
+        tokens[0] (the YES token) regardless of the requested outcome, so any NO-side order
+        silently traded the wrong outcome (issue #14). We match the token's 'outcome' field,
+        falling back to the index convention (tokens[0]=YES, tokens[1]=NO).
+        """
+        outcome = (outcome or "YES").upper()
+        if outcome not in ("YES", "NO"):
+            raise ValueError(f"outcome must be 'YES' or 'NO', got {outcome!r}")
+        if not tokens:
+            raise ValueError("No tokens available for token selection")
+        for token in tokens:
+            if str(token.get("outcome", "")).upper() == outcome:
+                return token["token_id"]
+        # Fallback: index convention when tokens lack an explicit 'outcome' field
+        if outcome == "YES":
+            return tokens[0]["token_id"]
+        if len(tokens) > 1:
+            return tokens[1]["token_id"]
+        raise ValueError(f"Cannot resolve NO token: market has only {len(tokens)} token(s)")
+
     async def create_limit_order(
         self,
         market_id: str,
@@ -53,7 +78,8 @@ class TradingTools:
         price: float,
         size: float,
         order_type: str = "GTC",
-        expiration: Optional[int] = None
+        expiration: Optional[int] = None,
+        outcome: str = "YES"
     ) -> Dict[str, Any]:
         """
         Create a limit order on Polymarket.
@@ -98,13 +124,13 @@ class TradingTools:
             logger.info(f"Fetching market data for {market_id}")
             market = await self.client.get_market(market_id)
 
-            # Get token ID (YES token for BUY, NO token for SELL on yes side typically)
-            # For simplicity, use first token. In production, implement proper token selection
+            # Resolve the correct outcome token (YES/NO). Previously always used tokens[0]
+            # (the YES token) regardless of requested outcome -> issue #14.
             tokens = market.get('tokens', [])
             if not tokens:
                 raise ValueError(f"No tokens found for market {market_id}")
 
-            token_id = tokens[0]['token_id']
+            token_id = self._select_token(tokens, outcome)
 
             # Get orderbook for validation
             orderbook = await self.client.get_orderbook(token_id)
@@ -220,7 +246,8 @@ class TradingTools:
         self,
         market_id: str,
         side: str,
-        size: float
+        size: float,
+        outcome: str = "YES"
     ) -> Dict[str, Any]:
         """
         Execute market order at best available price (FOK).
@@ -240,7 +267,7 @@ class TradingTools:
             if not tokens:
                 raise ValueError(f"No tokens found for market {market_id}")
 
-            token_id = tokens[0]['token_id']
+            token_id = self._select_token(tokens, outcome)
 
             # Get best price from orderbook
             orderbook = await self.client.get_orderbook(token_id)
@@ -373,7 +400,8 @@ class TradingTools:
         market_id: str,
         side: str,
         size: float,
-        strategy: str = 'mid'
+        strategy: str = 'mid',
+        outcome: str = "YES"
     ) -> Dict[str, Any]:
         """
         AI suggests optimal price for order.
@@ -396,7 +424,7 @@ class TradingTools:
             if not tokens:
                 raise ValueError(f"No tokens found for market {market_id}")
 
-            token_id = tokens[0]['token_id']
+            token_id = self._select_token(tokens, outcome)
             orderbook = await self.client.get_orderbook(token_id)
 
             # Parse orderbook
@@ -823,6 +851,9 @@ class TradingTools:
             else:
                 raise ValueError("Cannot determine BUY or SELL from intent")
 
+            # Determine outcome token (YES/NO) from intent; default YES
+            outcome = "NO" if re.search(r"\bno\b", intent_lower) else "YES"
+
             # Determine strategy
             if any(word in intent_lower for word in ['fast', 'quick', 'now', 'immediately']):
                 strategy = 'aggressive'
@@ -836,7 +867,8 @@ class TradingTools:
                 market_id=market_id,
                 side=side,
                 size=max_budget,
-                strategy=strategy
+                strategy=strategy,
+                outcome=outcome
             )
 
             if not price_suggestion.get('success'):
@@ -882,7 +914,8 @@ class TradingTools:
                     result = await self.create_market_order(
                         market_id=market_id,
                         side=side,
-                        size=plan['size']
+                        size=plan['size'],
+                        outcome=outcome
                     )
                 else:
                     result = await self.create_limit_order(
@@ -890,7 +923,8 @@ class TradingTools:
                         side=side,
                         price=plan['price'],
                         size=plan['size'],
-                        order_type='GTC'
+                        order_type='GTC',
+                        outcome=outcome
                     )
 
                 executed_orders.append(result)
@@ -928,7 +962,8 @@ class TradingTools:
         self,
         market_id: str,
         target_size: Optional[float] = None,
-        max_slippage: float = 0.02
+        max_slippage: float = 0.02,
+        outcome: str = "YES"
     ) -> Dict[str, Any]:
         """
         Adjust position to target size (or close if target_size is None).
@@ -986,7 +1021,7 @@ class TradingTools:
             if not tokens:
                 raise ValueError(f"No tokens found for market {market_id}")
 
-            token_id = tokens[0]['token_id']
+            token_id = self._select_token(tokens, outcome)
             orderbook = await self.client.get_orderbook(token_id)
 
             bids = orderbook.get('bids', [])
@@ -1115,6 +1150,12 @@ def get_tool_definitions() -> List[types.Tool]:
                         "minimum": 1,
                         "description": "Order size in USD"
                     },
+                    "outcome": {
+                        "type": "string",
+                        "enum": ["YES", "NO"],
+                        "default": "YES",
+                        "description": "Which market outcome token to trade (YES or NO). Distinct from side (BUY/SELL)."
+                    },
                     "order_type": {
                         "type": "string",
                         "enum": ["GTC", "GTD", "FOK", "FAK"],
@@ -1151,6 +1192,12 @@ def get_tool_definitions() -> List[types.Tool]:
                         "type": "number",
                         "minimum": 1,
                         "description": "Order size in USD"
+                    },
+                    "outcome": {
+                        "type": "string",
+                        "enum": ["YES", "NO"],
+                        "default": "YES",
+                        "description": "Which market outcome token to trade (YES or NO). Distinct from side (BUY/SELL)."
                     }
                 },
                 "required": ["market_id", "side", "size"]

--- a/src/polymarket_mcp/utils/websocket_manager.py
+++ b/src/polymarket_mcp/utils/websocket_manager.py
@@ -260,7 +260,8 @@ class WebSocketManager:
             auth_message = {
                 "auth": {
                     "apiKey": self.config.POLYMARKET_API_KEY,
-                    "secret": self.config.POLYMARKET_PASSPHRASE,
+                    "secret": (self.config.POLYMARKET_API_SECRET
+                               or self.config.POLYMARKET_PASSPHRASE),
                     "passphrase": self.config.POLYMARKET_PASSPHRASE
                 }
             }
@@ -792,33 +793,40 @@ class WebSocketManager:
         """
         logger.info("Background WebSocket loop started")
 
+        clob_task = None
+        realtime_task = None
         while self.should_run:
             try:
                 # Ensure connections are active
                 if not self.clob_connected or not self.realtime_connected:
+                    for _t in (clob_task, realtime_task):
+                        if _t is not None and not _t.done():
+                            _t.cancel()
+                    clob_task = realtime_task = None
                     await self.reconnect()
                     continue
 
-                # Process messages from both WebSockets
-                tasks = []
+                # Process both channels concurrently with persistent per-channel receive
+                # tasks. We NEVER cancel an in-flight recv(): the old FIRST_COMPLETED +
+                # cancel-pending logic starved whichever channel was quieter (issue #13).
+                if (self.clob_ws and not self.clob_ws.closed
+                        and (clob_task is None or clob_task.done())):
+                    clob_task = asyncio.create_task(self._receive_clob_messages())
+                if (self.realtime_ws and not self.realtime_ws.closed
+                        and (realtime_task is None or realtime_task.done())):
+                    realtime_task = asyncio.create_task(self._receive_realtime_messages())
 
-                if self.clob_ws and not self.clob_ws.closed:
-                    tasks.append(self._receive_clob_messages())
-
-                if self.realtime_ws and not self.realtime_ws.closed:
-                    tasks.append(self._receive_realtime_messages())
-
-                if tasks:
-                    # Wait for any message or timeout
-                    done, pending = await asyncio.wait(
-                        tasks,
+                pending = {t for t in (clob_task, realtime_task) if t is not None}
+                if pending:
+                    done, _ = await asyncio.wait(
+                        pending,
                         timeout=1.0,
                         return_when=asyncio.FIRST_COMPLETED
                     )
-
-                    # Cancel pending tasks
-                    for task in pending:
-                        task.cancel()
+                    # Surface receiver exceptions (e.g. ConnectionClosed) to trigger reconnect.
+                    for task in done:
+                        if task.exception() is not None:
+                            raise task.exception()
                 else:
                     await asyncio.sleep(1.0)
 

--- a/tests/test_critical_fixes_12_13_14.py
+++ b/tests/test_critical_fixes_12_13_14.py
@@ -1,0 +1,102 @@
+"""Regression tests for the 3 critical bugs fixed: #12, #13, #14.
+
+#12 portfolio crash: portfolio tools were handed a SafetyLimits object where a RateLimiter
+    was expected (server.py routed safety_limits into the rate_limiter slot).
+#13 websocket: the message loop was never started; WS auth reused the passphrase as the secret.
+#14 wrong-side trades: trading always used tokens[0] (the YES token) regardless of YES/NO.
+"""
+
+import pytest
+
+from polymarket_mcp.tools.trading import TradingTools
+from polymarket_mcp.utils.rate_limiter import RateLimiter, get_rate_limiter
+from polymarket_mcp.utils.safety_limits import SafetyLimits
+
+# ----------------------------------------------------------------- #14
+YES = {"token_id": "TOKEN_YES", "outcome": "Yes"}
+NO = {"token_id": "TOKEN_NO", "outcome": "No"}
+
+
+def test_select_token_matches_outcome_field():
+    assert TradingTools._select_token([YES, NO], "YES") == "TOKEN_YES"
+    assert TradingTools._select_token([YES, NO], "NO") == "TOKEN_NO"
+    # order-independent: still resolves by the outcome field, not position
+    assert TradingTools._select_token([NO, YES], "NO") == "TOKEN_NO"
+    assert TradingTools._select_token([NO, YES], "YES") == "TOKEN_YES"
+
+
+def test_select_token_default_is_yes():
+    assert TradingTools._select_token([YES, NO]) == "TOKEN_YES"
+
+
+def test_select_token_index_fallback_when_no_outcome_field():
+    toks = [{"token_id": "T0"}, {"token_id": "T1"}]
+    assert TradingTools._select_token(toks, "YES") == "T0"
+    assert TradingTools._select_token(toks, "NO") == "T1"
+
+
+def test_select_token_rejects_bad_outcome_and_empty():
+    with pytest.raises(ValueError):
+        TradingTools._select_token([YES, NO], "MAYBE")
+    with pytest.raises(ValueError):
+        TradingTools._select_token([], "YES")
+
+
+def test_trade_methods_accept_outcome_param():
+    import inspect
+
+    for name in (
+        "create_limit_order",
+        "create_market_order",
+        "suggest_order_price",
+        "rebalance_position",
+    ):
+        sig = inspect.signature(getattr(TradingTools, name))
+        assert "outcome" in sig.parameters, f"{name} missing outcome param"
+        assert sig.parameters["outcome"].default == "YES"
+
+
+# ----------------------------------------------------------------- #12
+def test_rate_limiter_has_acquire_but_safety_limits_does_not():
+    # the portfolio tools call rate_limiter.acquire(...); passing SafetyLimits there crashed.
+    rl = get_rate_limiter()
+    assert isinstance(rl, RateLimiter)
+    assert hasattr(rl, "acquire") and callable(rl.acquire)
+    assert not hasattr(SafetyLimits, "acquire")
+
+
+def test_server_routes_rate_limiter_not_safety_limits():
+    # guard against regressing the exact swap that caused the crash.
+    import inspect
+    from polymarket_mcp import server
+
+    src = inspect.getsource(server)
+    assert "get_rate_limiter()," in src.split("call_portfolio_tool")[1][:200]
+
+
+# ----------------------------------------------------------------- #13
+def test_websocket_init_starts_background_loop():
+    import inspect
+    from polymarket_mcp import server
+
+    src = inspect.getsource(server)
+    # connect() alone is not enough; the message loop must be started too.
+    assert "start_background_task()" in src
+
+
+def test_websocket_auth_secret_prefers_api_secret_over_passphrase():
+    import inspect
+    from polymarket_mcp.utils import websocket_manager
+
+    src = inspect.getsource(
+        websocket_manager._authenticate_clob
+        if hasattr(websocket_manager, "_authenticate_clob")
+        else websocket_manager.WebSocketManager._authenticate_clob
+    )
+    assert "POLYMARKET_API_SECRET" in src
+
+
+def test_config_exposes_api_secret_field():
+    from polymarket_mcp.config import PolymarketConfig
+
+    assert "POLYMARKET_API_SECRET" in PolymarketConfig.model_fields

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -429,7 +429,10 @@ class TestInstallationFlow:
         assert pyproject.exists()
 
         # Try to parse it
-        import tomllib if hasattr(__builtins__, 'tomllib') else None
+        try:
+            import tomllib
+        except ImportError:
+            tomllib = None
         if tomllib:
             with open(pyproject, 'rb') as f:
                 data = tomllib.load(f)


### PR DESCRIPTION
## Summary

Fixes the three open **CRITICAL** bugs, confirmed still present on `main`, plus a syntax error that was aborting pytest collection for the entire suite.

### 🔴 #14 — Wrong-side trades (the serious one)
Every order path used `tokens[0]` (the **YES** token) regardless of YES/NO, so any NO-side order silently traded the **wrong outcome** — real-money correctness bug. Added an `outcome` param (`YES`/`NO`, default `YES`) + a `_select_token()` helper that resolves by the token's `outcome` field (index fallback), across `create_limit_order`, `create_market_order`, `suggest_order_price`, `rebalance_position`, threaded through `execute_smart_trade` (parsed from intent), and exposed in the tool schemas. `outcome` is distinct from `side` (BUY/SELL). Backward-compatible: omitting `outcome` behaves exactly as before (YES).

### 🔴 #12 — Portfolio tools crashed on invocation
`server.py` passed `safety_limits` into the `rate_limiter` parameter of `call_portfolio_tool`, so every portfolio tool hit `SafetyLimits.acquire()` (nonexistent) → crash. Now passes the `RateLimiter` singleton.

### 🔴 #13 — Real-time WebSocket tools were dead
- `connect()` was scheduled but `start_background_task()` never was → the message loop never ran. Init now wraps `connect()` + `start_background_task()`.
- CLOB auth reused `POLYMARKET_PASSPHRASE` as the `secret`. Added a dedicated `POLYMARKET_API_SECRET` config field (falls back to passphrase for backward compat).
- The background loop's `FIRST_COMPLETED` + cancel-pending starved the quieter channel. Now runs **persistent per-channel receivers that are never cancelled mid-`recv()`**.

### 🧹 Test suite
- Fixed an **invalid conditional import** in `tests/test_e2e.py` (`import X if ... else None`) that was a **SyntaxError aborting pytest collection for the whole suite** — this is why the CI test matrix was fully red.
- Added `tests/test_critical_fixes_12_13_14.py` — **10 regression tests, all passing** (pure unit, no network).

## Verification
- **Zero test regressions** vs the pre-existing baseline (diffed the full failure set: nothing that passed before fails now; the 9 new regression tests go red→green).
- The remaining suite failures are **pre-existing** and unrelated: the trading/portfolio/websocket/e2e/performance tests call the **real Polymarket API / WebSocket / credentials** in setup and fail offline/in-CI. Marking or mocking those is a separate test-infra cleanup.
- Lint (`ruff`/`black`) on `main` is also red repo-wide pre-existing; this PR introduces no new lint debt in its changed lines but does not attempt the repo-wide format pass.

Supersedes the stale, conflicting #18 (which mixed these fixes with a large test rewrite and went red). This is a surgical, rebased version on current `main`.

Closes #12, closes #13, closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)