### PR TITLE
fix: real confirmation gate, YES/NO token selection, safe defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,8 @@ POLYMARKET_CHAIN_ID=137
 # Leave empty to auto-generate on first run
 # Or get from: https://polymarket.com/settings/api
 POLYMARKET_API_KEY=
+# L2 API secret (HMAC) - DISTINCT from the passphrase. Leave empty to auto-generate.
+POLYMARKET_API_SECRET=
 POLYMARKET_PASSPHRASE=
 POLYMARKET_API_KEY_NAME=
 
@@ -65,9 +67,10 @@ MAX_SPREAD_TOLERANCE=0.05
 # Trading Controls
 # ============================================================================
 
-# Enable autonomous trading without confirmation
-# WARNING: Use with caution! Set to false for manual approval
-ENABLE_AUTONOMOUS_TRADING=true
+# Enable autonomous trading without per-order confirmation.
+# SAFE DEFAULT: false -> EVERY order requires confirm=true to execute.
+# When true, only orders above REQUIRE_CONFIRMATION_ABOVE_USD require confirm=true.
+ENABLE_AUTONOMOUS_TRADING=false
 
 # Require user confirmation for orders above this USD amount
 REQUIRE_CONFIRMATION_ABOVE_USD=500

--- a/src/polymarket_mcp/auth/client.py
+++ b/src/polymarket_mcp/auth/client.py
@@ -57,11 +57,12 @@ class PolymarketClient:
         # L2 API credentials
         self.api_creds: Optional[ApiCreds] = None
         if api_key and (api_secret or passphrase):
-            secret = api_secret or passphrase
+            # api_secret (HMAC) and passphrase are DISTINCT fields. Fall back to the
+            # other only when one is missing (legacy single-value configs).
             self.api_creds = ApiCreds(
                 api_key=api_key,
-                api_secret=secret,
-                api_passphrase=secret
+                api_secret=api_secret or passphrase,
+                api_passphrase=passphrase or api_secret
             )
 
         # Initialize CLOB client

--- a/src/polymarket_mcp/config.py
+++ b/src/polymarket_mcp/config.py
@@ -46,6 +46,10 @@ class PolymarketConfig(BaseSettings):
         default=None,
         description="L2 API key for authenticated requests"
     )
+    POLYMARKET_API_SECRET: Optional[str] = Field(
+        default=None,
+        description="L2 API secret (HMAC). Distinct from passphrase. Auto-created if blank."
+    )
     POLYMARKET_PASSPHRASE: Optional[str] = Field(
         default=None,
         description="API key passphrase"
@@ -79,8 +83,12 @@ class PolymarketConfig(BaseSettings):
 
     # Trading Controls
     ENABLE_AUTONOMOUS_TRADING: bool = Field(
-        default=True,
-        description="Enable autonomous trading without confirmation"
+        default=False,
+        description=(
+            "Enable autonomous trading without per-order confirmation. "
+            "SAFE DEFAULT: False -> every order requires confirm=true. "
+            "When True, only orders above REQUIRE_CONFIRMATION_ABOVE_USD need confirm=true."
+        )
     )
     REQUIRE_CONFIRMATION_ABOVE_USD: float = Field(
         default=500.0,
@@ -205,6 +213,8 @@ class PolymarketConfig(BaseSettings):
             data["POLYGON_PRIVATE_KEY"] = "***HIDDEN***"
         if data.get("POLYMARKET_API_KEY"):
             data["POLYMARKET_API_KEY"] = "***HIDDEN***"
+        if data.get("POLYMARKET_API_SECRET"):
+            data["POLYMARKET_API_SECRET"] = "***HIDDEN***"
         if data.get("POLYMARKET_PASSPHRASE"):
             data["POLYMARKET_PASSPHRASE"] = "***HIDDEN***"
         return data

--- a/src/polymarket_mcp/server.py
+++ b/src/polymarket_mcp/server.py
@@ -353,7 +353,7 @@ async def initialize_server() -> None:
             address=config.POLYGON_ADDRESS,
             chain_id=config.POLYMARKET_CHAIN_ID,
             api_key=config.POLYMARKET_API_KEY,
-            api_secret=config.POLYMARKET_PASSPHRASE,
+            api_secret=config.POLYMARKET_API_SECRET,
             passphrase=config.POLYMARKET_PASSPHRASE,
         )
 

--- a/src/polymarket_mcp/tools/trading.py
+++ b/src/polymarket_mcp/tools/trading.py
@@ -5,6 +5,7 @@ Implements 12 comprehensive tools for order management and smart trading.
 import asyncio
 import json
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional, Tuple
 import mcp.types as types
@@ -364,7 +365,8 @@ class TradingTools:
 
     async def create_batch_orders(
         self,
-        orders: List[Dict[str, Any]]
+        orders: List[Dict[str, Any]],
+        confirm: bool = False
     ) -> Dict[str, Any]:
         """
         Submit multiple orders in batch.
@@ -377,6 +379,8 @@ class TradingTools:
                 - size (float)
                 - order_type (str, optional)
                 - expiration (int, optional)
+                - outcome (str, optional): 'YES'/'NO' or exact label
+            confirm: Must be True to execute orders that require confirmation.
 
         Returns:
             Dict with results for each order
@@ -399,7 +403,9 @@ class TradingTools:
                         price=order['price'],
                         size=order['size'],
                         order_type=order.get('order_type', 'GTC'),
-                        expiration=order.get('expiration')
+                        expiration=order.get('expiration'),
+                        outcome=order.get('outcome'),
+                        confirm=confirm
                     )
 
                     results.append({
@@ -445,7 +451,8 @@ class TradingTools:
         market_id: str,
         side: str,
         size: float,
-        strategy: str = 'mid'
+        strategy: str = 'mid',
+        outcome: Optional[str] = None
     ) -> Dict[str, Any]:
         """
         AI suggests optimal price for order.
@@ -455,6 +462,7 @@ class TradingTools:
             side: 'BUY' or 'SELL'
             size: Order size in USD
             strategy: 'aggressive'|'passive'|'mid'
+            outcome: Outcome to price ('YES'/'NO' or exact label). Defaults to YES.
 
         Returns:
             Dict with suggested price and reasoning
@@ -464,11 +472,7 @@ class TradingTools:
 
             # Get market data
             market = await self.client.get_market(market_id)
-            tokens = market.get('tokens', [])
-            if not tokens:
-                raise ValueError(f"No tokens found for market {market_id}")
-
-            token_id = tokens[0]['token_id']
+            token_id, _ = self._select_token(market, outcome)
             orderbook = await self.client.get_orderbook(token_id)
 
             # Parse orderbook
@@ -866,7 +870,9 @@ class TradingTools:
         self,
         market_id: str,
         intent: str,
-        max_budget: float
+        max_budget: float,
+        outcome: Optional[str] = None,
+        confirm: bool = False
     ) -> Dict[str, Any]:
         """
         AI-powered trade execution with natural language intent.
@@ -877,6 +883,9 @@ class TradingTools:
             market_id: Market condition ID
             intent: Natural language intent (e.g., "Buy YES at good price up to $100")
             max_budget: Maximum budget in USD
+            outcome: Outcome to trade ('YES'/'NO' or exact label). If None, inferred
+                     from the intent text (defaults to YES).
+            confirm: Must be True to execute orders that require confirmation.
 
         Returns:
             Dict with execution summary
@@ -895,6 +904,13 @@ class TradingTools:
             else:
                 raise ValueError("Cannot determine BUY or SELL from intent")
 
+            # Determine outcome (explicit param wins; else infer from intent words).
+            if not outcome:
+                if re.search(r'\bno\b', intent_lower):
+                    outcome = 'NO'
+                elif re.search(r'\byes\b', intent_lower):
+                    outcome = 'YES'
+
             # Determine strategy
             if any(word in intent_lower for word in ['fast', 'quick', 'now', 'immediately']):
                 strategy = 'aggressive'
@@ -903,12 +919,13 @@ class TradingTools:
             else:
                 strategy = 'mid'
 
-            # Get price suggestion
+            # Get price suggestion (for the chosen outcome)
             price_suggestion = await self.suggest_order_price(
                 market_id=market_id,
                 side=side,
                 size=max_budget,
-                strategy=strategy
+                strategy=strategy,
+                outcome=outcome
             )
 
             if not price_suggestion.get('success'):
@@ -954,7 +971,9 @@ class TradingTools:
                     result = await self.create_market_order(
                         market_id=market_id,
                         side=side,
-                        size=plan['size']
+                        size=plan['size'],
+                        outcome=outcome,
+                        confirm=confirm
                     )
                 else:
                     result = await self.create_limit_order(
@@ -962,7 +981,9 @@ class TradingTools:
                         side=side,
                         price=plan['price'],
                         size=plan['size'],
-                        order_type='GTC'
+                        order_type='GTC',
+                        outcome=outcome,
+                        confirm=confirm
                     )
 
                 executed_orders.append(result)
@@ -1000,7 +1021,9 @@ class TradingTools:
         self,
         market_id: str,
         target_size: Optional[float] = None,
-        max_slippage: float = 0.02
+        max_slippage: float = 0.02,
+        outcome: Optional[str] = None,
+        confirm: bool = False
     ) -> Dict[str, Any]:
         """
         Adjust position to target size (or close if target_size is None).
@@ -1009,6 +1032,8 @@ class TradingTools:
             market_id: Market condition ID
             target_size: Target position size in USD (None to close)
             max_slippage: Maximum acceptable slippage (default 2%)
+            outcome: Outcome to rebalance ('YES'/'NO' or exact label). Defaults to YES.
+            confirm: Must be True to execute when confirmation is required.
 
         Returns:
             Dict with rebalance summary
@@ -1054,11 +1079,7 @@ class TradingTools:
 
             # Get market data for slippage check
             market = await self.client.get_market(market_id)
-            tokens = market.get('tokens', [])
-            if not tokens:
-                raise ValueError(f"No tokens found for market {market_id}")
-
-            token_id = tokens[0]['token_id']
+            token_id, _ = self._select_token(market, outcome)
             orderbook = await self.client.get_orderbook(token_id)
 
             bids = orderbook.get('bids', [])
@@ -1094,7 +1115,9 @@ class TradingTools:
                 side=side,
                 price=expected_price,
                 size=size,
-                order_type='GTC'
+                order_type='GTC',
+                outcome=outcome,
+                confirm=confirm
             )
 
             return {
@@ -1266,11 +1289,17 @@ def get_tool_definitions() -> List[types.Tool]:
                                 "price": {"type": "number"},
                                 "size": {"type": "number"},
                                 "order_type": {"type": "string"},
-                                "expiration": {"type": "integer"}
+                                "expiration": {"type": "integer"},
+                                "outcome": {"type": "string", "description": "YES/NO or exact label"}
                             },
                             "required": ["market_id", "side", "price", "size"]
                         },
                         "description": "List of orders to submit"
+                    },
+                    "confirm": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Must be true to execute orders that require confirmation."
                     }
                 },
                 "required": ["orders"]
@@ -1303,6 +1332,10 @@ def get_tool_definitions() -> List[types.Tool]:
                         "enum": ["aggressive", "passive", "mid"],
                         "default": "mid",
                         "description": "Pricing strategy"
+                    },
+                    "outcome": {
+                        "type": "string",
+                        "description": "Outcome to price: 'YES'/'NO' or exact label. Defaults to YES."
                     }
                 },
                 "required": ["market_id", "side", "size"]
@@ -1426,6 +1459,15 @@ def get_tool_definitions() -> List[types.Tool]:
                     "max_budget": {
                         "type": "number",
                         "description": "Maximum budget in USD"
+                    },
+                    "outcome": {
+                        "type": "string",
+                        "description": "Outcome to trade: 'YES'/'NO' or exact label. If omitted, inferred from intent."
+                    },
+                    "confirm": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Must be true to execute orders that require confirmation."
                     }
                 },
                 "required": ["market_id", "intent", "max_budget"]
@@ -1452,6 +1494,15 @@ def get_tool_definitions() -> List[types.Tool]:
                         "type": "number",
                         "default": 0.02,
                         "description": "Maximum acceptable slippage (0.02 = 2%)"
+                    },
+                    "outcome": {
+                        "type": "string",
+                        "description": "Outcome to rebalance: 'YES'/'NO' or exact label. Defaults to YES."
+                    },
+                    "confirm": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Must be true to execute when confirmation is required."
                     }
                 },
                 "required": ["market_id"]

--- a/src/polymarket_mcp/tools/trading.py
+++ b/src/polymarket_mcp/tools/trading.py
@@ -44,6 +44,51 @@ class TradingTools:
         self.config = config
         self.rate_limiter = get_rate_limiter()
 
+    # ========== HELPERS ==========
+
+    @staticmethod
+    def _select_token(market: Dict[str, Any], outcome: Optional[str]) -> Tuple[str, str]:
+        """
+        Select the correct outcome token from a binary/multi-outcome market.
+
+        Args:
+            market: Market dict containing a 'tokens' list (each with token_id/outcome).
+            outcome: Desired outcome label (e.g. 'YES'/'NO', or the exact outcome string).
+                     If None, defaults to the first outcome (typically YES).
+
+        Returns:
+            Tuple of (token_id, resolved_outcome_label).
+
+        Raises:
+            ValueError: If no tokens exist or the requested outcome is not found.
+        """
+        tokens = market.get('tokens', [])
+        if not tokens:
+            raise ValueError("No tokens found for market")
+
+        # Default: first outcome (typically YES) - preserves legacy behavior.
+        if not outcome:
+            first = tokens[0]
+            return first['token_id'], str(first.get('outcome', 'YES'))
+
+        target = outcome.strip().lower()
+
+        # 1) Exact match on the outcome label.
+        for t in tokens:
+            if str(t.get('outcome', '')).strip().lower() == target:
+                return t['token_id'], str(t.get('outcome', outcome))
+
+        # 2) Common aliases mapped to conventional index (YES=0, NO=1).
+        if target in ('yes', 'true', '1') and len(tokens) >= 1:
+            return tokens[0]['token_id'], str(tokens[0].get('outcome', 'YES'))
+        if target in ('no', 'false', '0') and len(tokens) >= 2:
+            return tokens[1]['token_id'], str(tokens[1].get('outcome', 'NO'))
+
+        available = [str(t.get('outcome', '?')) for t in tokens]
+        raise ValueError(
+            f"Outcome '{outcome}' not found in market. Available outcomes: {available}"
+        )
+
     # ========== ORDER CREATION TOOLS ==========
 
     async def create_limit_order(
@@ -53,7 +98,9 @@ class TradingTools:
         price: float,
         size: float,
         order_type: str = "GTC",
-        expiration: Optional[int] = None
+        expiration: Optional[int] = None,
+        outcome: Optional[str] = None,
+        confirm: bool = False
     ) -> Dict[str, Any]:
         """
         Create a limit order on Polymarket.
@@ -98,13 +145,9 @@ class TradingTools:
             logger.info(f"Fetching market data for {market_id}")
             market = await self.client.get_market(market_id)
 
-            # Get token ID (YES token for BUY, NO token for SELL on yes side typically)
-            # For simplicity, use first token. In production, implement proper token selection
-            tokens = market.get('tokens', [])
-            if not tokens:
-                raise ValueError(f"No tokens found for market {market_id}")
-
-            token_id = tokens[0]['token_id']
+            # Select the correct outcome token (YES/NO/...) instead of blindly using tokens[0].
+            token_id, resolved_outcome = self._select_token(market, outcome)
+            logger.info(f"Selected outcome '{resolved_outcome}' (token {token_id}) for {market_id}")
 
             # Get orderbook for validation
             orderbook = await self.client.get_orderbook(token_id)
@@ -156,17 +199,40 @@ class TradingTools:
             if not is_valid:
                 raise ValueError(f"Safety check failed: {error_msg}")
 
-            # Check if confirmation required
+            # REAL confirmation gate (human-in-the-loop). If confirmation is required and
+            # the caller did not pass confirm=True, DO NOT place the order - return a
+            # pending response so the client/user can explicitly approve.
             if self.safety_limits.should_require_confirmation(
                 order_request,
                 self.config.ENABLE_AUTONOMOUS_TRADING
-            ):
-                logger.warning(
-                    f"Order requires confirmation: ${size:.2f} exceeds threshold "
-                    f"${self.config.REQUIRE_CONFIRMATION_ABOVE_USD:.2f}"
+            ) and not confirm:
+                reason = (
+                    "autonomous trading is disabled"
+                    if not self.config.ENABLE_AUTONOMOUS_TRADING
+                    else (
+                        f"order size ${size:.2f} exceeds confirmation threshold "
+                        f"${self.config.REQUIRE_CONFIRMATION_ABOVE_USD:.2f}"
+                    )
                 )
-                # In autonomous mode, we proceed with logging
-                # In interactive mode, this would prompt the user
+                logger.warning(f"Order NOT placed - confirmation required ({reason})")
+                return {
+                    "success": False,
+                    "status": "confirmation_required",
+                    "requires_confirmation": True,
+                    "message": (
+                        f"This order was NOT placed because {reason}. "
+                        f"Review the details and call again with confirm=true to execute."
+                    ),
+                    "pending_order": {
+                        "market_id": market_id,
+                        "outcome": resolved_outcome,
+                        "side": side,
+                        "price": price,
+                        "size_usd": size,
+                        "size_shares": size_in_shares,
+                        "order_type": order_type,
+                    }
+                }
 
             # Post order
             logger.info(
@@ -190,6 +256,7 @@ class TradingTools:
                 "details": {
                     "market_id": market_id,
                     "token_id": token_id,
+                    "outcome": resolved_outcome,
                     "side": side,
                     "price": price,
                     "size_shares": size_in_shares,
@@ -220,7 +287,9 @@ class TradingTools:
         self,
         market_id: str,
         side: str,
-        size: float
+        size: float,
+        outcome: Optional[str] = None,
+        confirm: bool = False
     ) -> Dict[str, Any]:
         """
         Execute market order at best available price (FOK).
@@ -229,6 +298,8 @@ class TradingTools:
             market_id: Market condition ID
             side: 'BUY' or 'SELL'
             size: Order size in USD
+            outcome: Outcome to trade ('YES'/'NO' or exact label). Defaults to YES.
+            confirm: Must be True to execute when confirmation is required.
 
         Returns:
             Dict with execution details
@@ -236,11 +307,9 @@ class TradingTools:
         try:
             # Get current best price
             market = await self.client.get_market(market_id)
-            tokens = market.get('tokens', [])
-            if not tokens:
-                raise ValueError(f"No tokens found for market {market_id}")
 
-            token_id = tokens[0]['token_id']
+            # Select the correct outcome token (not blindly tokens[0]).
+            token_id, resolved_outcome = self._select_token(market, outcome)
 
             # Get best price from orderbook
             orderbook = await self.client.get_orderbook(token_id)
@@ -263,13 +332,16 @@ class TradingTools:
                 f"Executing market order: {side} ${size} @ market price {best_price}"
             )
 
-            # Use FOK (Fill-Or-Kill) for market orders
+            # Use FOK (Fill-Or-Kill) for market orders. Pass outcome + confirm through so
+            # the real confirmation gate and outcome selection are honored.
             result = await self.create_limit_order(
                 market_id=market_id,
                 side=side,
                 price=best_price,
                 size=size,
-                order_type='FOK'
+                order_type='FOK',
+                outcome=resolved_outcome,
+                confirm=confirm
             )
 
             result['execution_type'] = 'market_order'
@@ -1124,6 +1196,15 @@ def get_tool_definitions() -> List[types.Tool]:
                     "expiration": {
                         "type": "integer",
                         "description": "Unix timestamp for GTD orders (optional)"
+                    },
+                    "outcome": {
+                        "type": "string",
+                        "description": "Outcome to trade: 'YES'/'NO' or the exact outcome label. Defaults to YES."
+                    },
+                    "confirm": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Must be true to execute when confirmation is required (large size or non-autonomous mode)."
                     }
                 },
                 "required": ["market_id", "side", "price", "size"]
@@ -1151,6 +1232,15 @@ def get_tool_definitions() -> List[types.Tool]:
                         "type": "number",
                         "minimum": 1,
                         "description": "Order size in USD"
+                    },
+                    "outcome": {
+                        "type": "string",
+                        "description": "Outcome to trade: 'YES'/'NO' or the exact outcome label. Defaults to YES."
+                    },
+                    "confirm": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Must be true to execute when confirmation is required (large size or non-autonomous mode)."
                     }
                 },
                 "required": ["market_id", "side", "size"]

--- a/tests/test_safety_fixes.py
+++ b/tests/test_safety_fixes.py
@@ -116,9 +116,58 @@ def test_autonomous_small_order_no_confirm_needed():
     print("PASS test_autonomous_small_order_no_confirm_needed")
 
 
+def test_batch_gated_then_confirmed():
+    """Batch orders honor the gate: blocked without confirm, posted with confirm."""
+    tools, client = _make_tools(autonomous=False)
+    orders = [{"market_id": "0xM", "side": "BUY", "price": 0.5, "size": 10, "outcome": "NO"}]
+    blocked = asyncio.run(tools.create_batch_orders(orders))
+    assert client.post_calls == [], "batch must not post without confirm"
+    assert blocked["results"][0]["success"] is False
+    ok = asyncio.run(tools.create_batch_orders(orders, confirm=True))
+    assert ok["successful"] == 1, ok
+    assert client.post_calls[0]["token_id"] == "tok_no"
+    print("PASS test_batch_gated_then_confirmed")
+
+
+def test_rebalance_outcome_and_gate():
+    """Rebalance selects the requested outcome and respects the gate."""
+    tools, client = _make_tools(autonomous=False)
+    blocked = asyncio.run(tools.rebalance_position(
+        market_id="0xM", target_size=50, outcome="NO"
+    ))
+    assert client.post_calls == [], "rebalance must not post without confirm"
+    assert blocked["order_result"]["status"] == "confirmation_required"
+    ok = asyncio.run(tools.rebalance_position(
+        market_id="0xM", target_size=50, outcome="NO", confirm=True
+    ))
+    assert ok["success"] is True, ok
+    assert client.post_calls[0]["token_id"] == "tok_no"
+    print("PASS test_rebalance_outcome_and_gate")
+
+
+def test_smart_trade_infers_no_and_gates():
+    """Smart trade infers NO from intent text and does not post without confirm."""
+    tools, client = _make_tools(autonomous=False)
+    blocked = asyncio.run(tools.execute_smart_trade(
+        market_id="0xM", intent="Buy NO now", max_budget=20
+    ))
+    assert client.post_calls == [], "smart trade must not post without confirm"
+    # With confirm, it should post the NO token.
+    tools2, client2 = _make_tools(autonomous=False)
+    asyncio.run(tools2.execute_smart_trade(
+        market_id="0xM", intent="Buy NO now", max_budget=20, confirm=True
+    ))
+    assert client2.post_calls, "smart trade should post with confirm"
+    assert all(c["token_id"] == "tok_no" for c in client2.post_calls), client2.post_calls
+    print("PASS test_smart_trade_infers_no_and_gates")
+
+
 if __name__ == "__main__":
     test_select_token()
     test_confirmation_blocks_without_confirm()
     test_confirm_true_executes_and_uses_no_token()
     test_autonomous_small_order_no_confirm_needed()
+    test_batch_gated_then_confirmed()
+    test_rebalance_outcome_and_gate()
+    test_smart_trade_infers_no_and_gates()
     print("\nALL SAFETY-FIX TESTS PASSED")

--- a/tests/test_safety_fixes.py
+++ b/tests/test_safety_fixes.py
@@ -1,0 +1,124 @@
+"""
+Deterministic, offline tests for the safety fixes:
+  - Real confirmation gate (orders are NOT placed without confirm=true)
+  - Correct YES/NO outcome token selection (no more blind tokens[0])
+
+Run directly:  python tests/test_safety_fixes.py
+Or via pytest:  pytest tests/test_safety_fixes.py
+"""
+import asyncio
+from types import SimpleNamespace
+
+from polymarket_mcp.tools.trading import TradingTools
+from polymarket_mcp.utils.safety_limits import SafetyLimits
+
+
+class FakeClient:
+    """Minimal async stand-in for PolymarketClient (no network)."""
+
+    def __init__(self):
+        self.post_calls = []
+
+    async def get_market(self, market_id):
+        return {
+            "tokens": [
+                {"token_id": "tok_yes", "outcome": "Yes"},
+                {"token_id": "tok_no", "outcome": "No"},
+            ],
+            "volume": 100000,
+        }
+
+    async def get_orderbook(self, token_id):
+        return {
+            "bids": [{"price": "0.49", "size": "1000"}],
+            "asks": [{"price": "0.51", "size": "1000"}],
+        }
+
+    async def get_positions(self):
+        return []
+
+    async def post_order(self, **kwargs):
+        self.post_calls.append(kwargs)
+        return {"orderID": "ORDER-123", "status": "submitted"}
+
+
+def _make_tools(autonomous: bool):
+    client = FakeClient()
+    limits = SafetyLimits(
+        max_order_size_usd=1000,
+        max_total_exposure_usd=5000,
+        max_position_size_per_market=2000,
+        min_liquidity_required=100,
+        max_spread_tolerance=0.05,
+        require_confirmation_above_usd=500,
+        auto_cancel_on_large_spread=True,
+    )
+    config = SimpleNamespace(
+        ENABLE_AUTONOMOUS_TRADING=autonomous,
+        REQUIRE_CONFIRMATION_ABOVE_USD=500,
+    )
+    return TradingTools(client=client, safety_limits=limits, config=config), client
+
+
+def test_select_token():
+    tools, _ = _make_tools(autonomous=True)
+    market = {"tokens": [
+        {"token_id": "tok_yes", "outcome": "Yes"},
+        {"token_id": "tok_no", "outcome": "No"},
+    ]}
+    assert tools._select_token(market, None) == ("tok_yes", "Yes")
+    assert tools._select_token(market, "YES") == ("tok_yes", "Yes")
+    assert tools._select_token(market, "no") == ("tok_no", "No")
+    assert tools._select_token(market, "No")[0] == "tok_no"
+    try:
+        tools._select_token(market, "banana")
+        raise AssertionError("expected ValueError for unknown outcome")
+    except ValueError:
+        pass
+    print("PASS test_select_token")
+
+
+def test_confirmation_blocks_without_confirm():
+    """autonomous=False -> even a tiny order must NOT be placed without confirm=true."""
+    tools, client = _make_tools(autonomous=False)
+    result = asyncio.run(tools.create_limit_order(
+        market_id="0xMARKET", side="BUY", price=0.5, size=10, outcome="NO"
+    ))
+    assert result["success"] is False, result
+    assert result["status"] == "confirmation_required", result
+    assert client.post_calls == [], "order must NOT have been posted"
+    assert result["pending_order"]["outcome"] == "No"
+    print("PASS test_confirmation_blocks_without_confirm")
+
+
+def test_confirm_true_executes_and_uses_no_token():
+    """confirm=true -> order is posted, and it trades the NO token (not tokens[0])."""
+    tools, client = _make_tools(autonomous=False)
+    result = asyncio.run(tools.create_limit_order(
+        market_id="0xMARKET", side="BUY", price=0.5, size=10, outcome="NO", confirm=True
+    ))
+    assert result["success"] is True, result
+    assert len(client.post_calls) == 1, "order should have been posted exactly once"
+    assert client.post_calls[0]["token_id"] == "tok_no", client.post_calls[0]
+    assert result["details"]["outcome"] == "No"
+    print("PASS test_confirm_true_executes_and_uses_no_token")
+
+
+def test_autonomous_small_order_no_confirm_needed():
+    """autonomous=True + below threshold -> executes without confirm."""
+    tools, client = _make_tools(autonomous=True)
+    result = asyncio.run(tools.create_limit_order(
+        market_id="0xMARKET", side="BUY", price=0.5, size=10
+    ))
+    assert result["success"] is True, result
+    assert len(client.post_calls) == 1
+    assert client.post_calls[0]["token_id"] == "tok_yes"  # default outcome
+    print("PASS test_autonomous_small_order_no_confirm_needed")
+
+
+if __name__ == "__main__":
+    test_select_token()
+    test_confirmation_blocks_without_confirm()
+    test_confirm_true_executes_and_uses_no_token()
+    test_autonomous_small_order_no_confirm_needed()
+    print("\nALL SAFETY-FIX TESTS PASSED")


### PR DESCRIPTION
## 📋 Description

This PR makes the advertised trading safety actually work, fixes a wrong-side-trade bug, and hardens defaults. All order-placing tools are covered.

### 1. Real confirmation gate (was a no-op) — 🐛
`create_limit_order` / `create_market_order` previously called `should_require_confirmation(...)`, **logged a warning, and then submitted the order anyway** (the code even commented "in interactive mode, this would prompt the user"). So `REQUIRE_CONFIRMATION_ABOVE_USD` had no effect.

Now, when confirmation is required, the tools return:
```json
{ "success": false, "status": "confirmation_required", "requires_confirmation": true,
  "message": "...call again with confirm=true to execute", "pending_order": { ... } }
```
and **do not place the order** unless called with `confirm=true`.

### 2. Correct outcome (YES/NO) selection — 🐛
Orders used `tokens[0]` unconditionally (the code said *"In production, implement proper token selection"*), making it impossible to reliably trade the NO side and risking wrong-side fills. A new `outcome` param (`"YES"`/`"NO"` or the exact label) selects the matching token via `_select_token()`. `execute_smart_trade` infers the outcome from the intent text (word-boundary match, so "now" is not read as "no").

### 3. Safe default — 🔧
`ENABLE_AUTONOMOUS_TRADING` now defaults to `False` (every order requires `confirm=true`) instead of `True`, matching the documentation.

### 4. Correct L2 credentials — 🐛
`api_secret` (HMAC) and `passphrase` are now distinct (new `POLYMARKET_API_SECRET`); previously both were set to the passphrase, which breaks manually-configured L2 auth.

### Coverage
Gate + outcome threaded through **every** order-placing path: `create_limit_order`, `create_market_order`, `create_batch_orders` (per-order `outcome`, batch `confirm`), `execute_smart_trade`, `rebalance_position`. `suggest_order_price` gained `outcome` so quotes match the intended token. Last two `tokens[0]` usages removed. All MCP tool schemas updated.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 💥 Breaking change (default of ENABLE_AUTONOMOUS_TRADING flips to False)
- [x] 🧪 Test improvements

## 🧪 Testing
Added `tests/test_safety_fixes.py` — 7 offline, deterministic tests (no network) covering the gate and outcome selection across limit, market, batch, smart-trade, and rebalance. All pass. Server boots clean in DEMO mode; tool schemas validated.

## Notes
Backward-compatible API: `outcome` defaults to YES (legacy behavior) and `confirm` defaults to False. The only behavior change is the now-enforced confirmation gate and the safer autonomous default.